### PR TITLE
Use int64 type for timestamp values

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -17,7 +17,7 @@ func TestNewClient(t *testing.T) {
 func TestMessage_Client(t *testing.T) {
 	oldTimeStamp := TimeStamp
 	defer func() { TimeStamp = oldTimeStamp }()
-	TimeStamp = func() int { return 998877 }
+	TimeStamp = func() int64 { return 998877 }
 	c := New("foo-bar-baz")
 
 	t.Run("default", func(t *testing.T) {

--- a/event.go
+++ b/event.go
@@ -16,14 +16,14 @@ type Event struct {
 	APIKey     string          `json:"api_key"`
 	UserID     string          `json:"user_id"`
 	Intent     string          `json:"intent"`
-	TimeStamp  int             `json:"timestamp_millis,omitempty"`
+	TimeStamp  int64           `json:"timestamp_millis,omitempty"`
 	Platform   string          `json:"platform,omitempty"`
 	Version    string          `json:"version,omitempty"`
 	Properties []EventProperty `json:"properties"`
 }
 
 // SetTimeStamp adds an optional "timestamp" value to the event
-func (e *Event) SetTimeStamp(t int) *Event {
+func (e *Event) SetTimeStamp(t int64) *Event {
 	e.TimeStamp = t
 	return e
 }

--- a/message.go
+++ b/message.go
@@ -50,7 +50,7 @@ type Message struct {
 	APIKey     string      `json:"api_key"`
 	Type       MessageType `json:"type"`
 	UserID     string      `json:"user_id"`
-	TimeStamp  int         `json:"time_stamp"`
+	TimeStamp  int64       `json:"time_stamp"`
 	Platform   string      `json:"platform"`
 	Message    string      `json:"message,omitempty"`
 	Intent     string      `json:"intent,omitempty"`
@@ -90,7 +90,7 @@ func (m *Message) SetVersion(v string) *Message {
 }
 
 // SetTimeStamp overrides the message's "timestamp" value
-func (m *Message) SetTimeStamp(t int) *Message {
+func (m *Message) SetTimeStamp(t int64) *Message {
 	m.TimeStamp = t
 	return m
 }

--- a/timestamp.go
+++ b/timestamp.go
@@ -5,6 +5,6 @@ import (
 )
 
 // TimeStamp returns the current time in UNIX milliseconds
-var TimeStamp = func() int {
-	return int(time.Now().UnixNano() / 1e6)
+var TimeStamp = func() int64 {
+	return time.Now().UnixNano() / 1e6
 }


### PR DESCRIPTION
Following up on #4 

This changes API surface and therefore needs to be tagged as `v2.0.0`