### PR TITLE
Added go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Use `go get`:
 $ go get github.com/m90/go-chatbase
 ```
 
+or if you're using [go modules](https://github.com/golang/go/wiki/Modules), just specify:
+
+```go
+import "github.com/m90/go-chatbase/v2"
+```
+
 ## Example
 
 Send a single message to Chatbase:

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/m90/go-chatbase/v2


### PR DESCRIPTION
After merging, tag this commit as `v2.0.1`.

Adding `go.mod` enables better integration with [go modules](https://github.com/golang/go/wiki/Modules) (since go 1.11). Without this file, you can't easily add a dependency for >=v2, because go modules require you to have go.mod and a tag. Without go.mod:
```
$ go get github.com/m90/go-chatbase/v2
go: github.com/m90/go-chatbase/v2@v2.0.0: missing github.com/m90/go-chatbase/go.mod and .../v2/go.mod at revision v2.0.0
go: error loading module requirements
```
With go.mod download goes smooth.